### PR TITLE
refactor: Preferences クラスを作成

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -12,7 +12,7 @@ import { changeLoadingLogo } from "@content/functions/changeIcon";
 import { setTitleObserver } from "@content/functions/replaceTitleX";
 import { runSettingComponentObserver } from "@content/settings/ui";
 import { placePrintPrefButton } from "./printPref";
-import { getPref, mergeDefaultPref, setPref, updatePref } from "@content/settings";
+import { getPref, mergeDefaultPref, setPref, migratePref } from "@content/settings";
 import { waitForElement } from "@content/utils/element";
 
 (async () => {
@@ -36,7 +36,7 @@ import { waitForElement } from "@content/utils/element";
             // NOTE: i18n データのフェッチ
             loadI18n(),
             // NOTE: 設定の更新
-            updatePref(),
+            migratePref(),
 
             // NOTE: Twitter のレンダリングを待機
             waitForElement("#react-root"),

--- a/src/content/settings/index.ts
+++ b/src/content/settings/index.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SETTINGS } from "./settings";
-import type { Settings, SettingKeys, SettingFullKeys, SettingKeyType, SettingGroupKeys, SettingKeyDefault, SettingGroupChildIds } from "./settings";
+import type { Settings, SettingKeys, SettingFullKeys, SettingGroupKeys, SettingKeyDefault, SettingGroupChildIds } from "./settings";
 
 // TODO: 暫定的対応
 export type { SettingGroupKeys, SettingFullKeys, SettingGroupChildIds } from "./settings";
@@ -99,6 +99,7 @@ export class NestedPreferences<T extends JsonValue> extends Preferences<T> {
 
 // MARK: Migrates
 
+// eslint-disable-next-line ts/no-unsafe-declaration-merging
 export interface MigratableNestedPreferences extends NestedPreferences<DefaultPreferencesData> {
     // NOTE: 古い設定は型定義から削除されていることがあるため、最新の設定型定義を補完しつつ、存在しないキーを受け入れるようにする
     // こうすることで、例えば以下のように推論される:
@@ -108,10 +109,11 @@ export interface MigratableNestedPreferences extends NestedPreferences<DefaultPr
     // 存在しなくなったが強制的に使用したい、かつ値に特定の型を要求するキーを使用する際、第二ジェネリクスで明示する必要が出てくることにより、多少明示的になる
 
     // TODO: V = any は型定義が厳密になれば T[K] に置き換えられる
-    get<V = any, K extends string = SettingKeys>(identifier: K): V;
-    set<K extends string = SettingKeys, V = any>(identifier: K, value: V): this;
-    delete<K extends string = SettingKeys>(identifier: K): this;
+    get: <V = any, K extends string = SettingKeys>(identifier: K) => V;
+    set: <K extends string = SettingKeys, V = any>(identifier: K, value: V) => this;
+    delete: <K extends string = SettingKeys>(identifier: K) => this;
 }
+// eslint-disable-next-line ts/no-unsafe-declaration-merging
 export class MigratableNestedPreferences extends NestedPreferences<DefaultPreferencesData> {
     /**
      * `oldKey` の設定が true であれば `newKey` に `newValue` を設定し、`oldKey` を削除します。

--- a/src/content/settings/index.ts
+++ b/src/content/settings/index.ts
@@ -132,11 +132,21 @@ export class MigratableNestedPreferences extends NestedPreferences<DefaultPrefer
         if (typeof this.get("timeline") !== "object") this.set("timeline", {});
         if (typeof this.get("rightSidebar") !== "object") this.set("rightSidebar", {});
         if (typeof this.get("XToTwitter") !== "object") this.set("XToTwitter", {});
+        if (typeof this.get("tweetDisplaySetting") !== "object") this.set("tweetDisplaySetting", {});
+
+        if (typeof this.get("profileSetting") !== "object") this.set("profileSetting", {});
+        if (typeof this.get("profileSetting.invisible") !== "object") this.set("profileSetting.invisible", {});
+
+        if (typeof this.get("sidebarSetting") !== "object") this.set("sidebarSetting", {});
+        if (typeof this.get("sidebarSetting.buttonConfig") !== "object") this.set("sidebarSetting.buttonConfig", {});
+
         if (typeof this.get("twitterIcon") === "string") {
             const twitterIconPref = this.get<string, "twitterIcon">("twitterIcon");
             this.set("twitterIcon", {});
             this.set("twitterIcon.icon", twitterIconPref);
         }
+        if (typeof this.get("twitterIcon") !== "object") this.set("twitterIcon", {});
+        if (typeof this.get("twitterIcon.options") !== "object") this.set("twitterIcon.options", {});
         if (typeof this.get("clientInfo") === "object") this.delete("clientInfo");
 
         const boolKeys = {
@@ -209,6 +219,16 @@ export class MigratableNestedPreferences extends NestedPreferences<DefaultPrefer
     /** 設定バージョンを 1 から 2 に移行します。 */
     #migrateToV2(): void {
         if (this.get<number, "prefVersion">("prefVersion") < 1) this.#migrateToV1();
+
+        if (typeof this.get("tweetDisplaySetting") !== "object") this.set("tweetDisplaySetting", {});
+        if (typeof this.get("tweetDisplaySetting.invisible") !== "object") this.set("tweetDisplaySetting.invisible", {});
+        if (typeof this.get("tweetDisplaySetting.option") !== "object") this.set("tweetDisplaySetting.option", {});
+        if (typeof this.get("tweetDisplaySetting.buttonsInvisible") !== "object") this.set("tweetDisplaySetting.buttonsInvisible", {});
+
+        if (typeof this.get("engagementsLink") !== "object") this.set("engagementsLink", {});
+        if (typeof this.get("engagementsLink.option") !== "object") this.set("engagementsLink.option", {});
+
+        if (typeof this.get("showLinkCardInfo") !== "object") this.set("showLinkCardInfo", {});
 
         const boolKeys = {
             "tweetDisplaySetting.twitter-pro-promotion-btn": "tweetDisplaySetting.invisible.twitter-pro-promotion-btn",

--- a/src/content/settings/index.ts
+++ b/src/content/settings/index.ts
@@ -113,13 +113,13 @@ export interface MigratableNestedPreferences extends NestedPreferences<DefaultPr
 }
 export class MigratableNestedPreferences extends NestedPreferences<DefaultPreferencesData> {
     /**
-     * `oldKey` の設定が truthy であれば `newKey` に `newValue` を設定し、`oldKey` を削除します。
-     * `oldKey` の設定が falsy であれば `oldKey` の削除だけを行います。
+     * `oldKey` の設定が true であれば `newKey` に `newValue` を設定し、`oldKey` を削除します。
+     * `oldKey` の設定が true でなければ `oldKey` の削除だけを行います。
      *
      * boolean 値の設定キーを変更することを想定しています。
      * @param oldKey 変更元のキー
      * @param newKey 変更先のキー
-     * @param newValue 指定された値が truthy だった場合の置き換え先の値
+     * @param newValue 指定された値が true だった場合の置き換え先の値
      */
     #migrateBoolean<K1 extends string = SettingKeys, K2 extends string = SettingKeys>(oldKey: K1, newKey: K2, newValue: string | boolean = true): void {
         if (this.get(oldKey) === true) this.set(newKey, newValue);

--- a/src/content/settings/index.ts
+++ b/src/content/settings/index.ts
@@ -3,89 +3,305 @@ import { DEFAULT_SETTINGS, type SettingKeys } from "./settings";
 // TODO: 暫定的対応
 export type { SettingKeys };
 
-let settings = null;
+// MARK: Class
 
-const getPointerFromKey = (object: object, key: string) => {
-    const keys = ["o", ...key.split(".").filter((k) => k !== "")];
-    let pointer = { o: object };
-    for (let i = 0; i < keys.length; i++) {
-        const k = keys[i];
-        if (i === keys.length - 1) {
-            return {
-                object: pointer,
-                key: k,
-            };
-        } else {
-            if (!(k in pointer)) {
-                pointer[k] = {};
+/** JSON のプリミティブ型 */
+type JsonPrimitive = string | number | boolean | null;
+/** JSON としてシリアライズできる型 */
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+/** 指定されたオブジェクト中の、JSON としてシリアライズ可能なキー */
+type JsonKeyOf<T> = Extract<keyof T, string>;
+
+/** TUIC で使用する設定データ型 */
+type DefaultPreferencesData = Record<SettingKeys, any>;
+/** TUIC で使用する設定データ型を操作可能なクラス型 */
+type DefaultPreferencesClass = Preferences<DefaultPreferencesData>;
+
+export abstract class Preferences<T extends JsonValue> {
+    /** この設定のルートオブジェクト */
+    protected value: T;
+
+    public constructor(value: T) {
+        this.value = value;
+    }
+
+    /** この設定を文字列としてシリアライズします。*/
+    public abstract serialize(): string;
+
+    /**
+     * 指定された ID を持つ設定値を取得します。
+     * @param identifier 設定 ID
+     */
+    public abstract get(identifier: JsonKeyOf<T>): T[JsonKeyOf<T>];
+
+    /**
+     * 指定された ID を持つ設定値に、指定された値を代入します。
+     * @param identifier 設定 ID
+     */
+    public abstract set<K extends JsonKeyOf<T>>(identifier: K, value: T[K]): this;
+
+    /**
+     * 指定された ID を持つ設定値を削除します。
+     * @param identifier 設定 ID
+     */
+    public abstract delete(identifier: JsonKeyOf<T>): this;
+}
+
+/** ドットで区切られた設定 ID を内部的にネストされたオブジェクトとして扱える設定クラス */
+export class NestedPreferences<T extends JsonValue> extends Preferences<T> {
+    public constructor(value: T) {
+        super(value);
+    }
+
+    public serialize(): string {
+        return JSON.stringify(this.value);
+    }
+
+    /**
+     * 指定されたキーに基づいて、ネストされたオブジェクトからオブジェクトとキー名を取得します。
+     * @param object ネストされたオブジェクト
+     * @param key ドット区切りのキー文字列
+     * @return オブジェクトとキー名のペア
+     */
+    #getPointer(object: any, key: string): { object: any; key: string } {
+        const keys = ["o", ...key.split(".").filter((k) => k !== "")];
+        let pointer = { o: object } as any;
+        for (const [i, key] of keys.slice(0, -1).entries()) {
+            if (!(key in pointer)) {
+                throw new TypeError(`Cannot access property "${key}", because ${keys.slice(0, i).join(".")} is undefined`);
             }
-            pointer = pointer[k];
+            pointer = pointer[key];
         }
+        return {
+            object: pointer,
+            key: keys[keys.length - 1],
+        };
     }
-};
 
-/**
- * TUICのPrefの値を取得します。
- *
- * @param {string} identifier 取得するPrefへのパス(ピリオド区切り)。
- * @param {object} source 使用するPrefのObject。
- * @return {unknown} 取得した値(identifierが空文字ならTUICのPref全体)
- */
-export function getPref<T = any>(identifier: string, source = settings): T {
-    const { object, key } = getPointerFromKey(source, identifier);
-    return object[key];
-}
-
-/**
- * TUICのPrefの値を設定します。
- *
- * identifierが空文字ならTUICのPref全体が変更されます。
- * @param {string} identifier 取得するPrefへのパス(ピリオド区切り)。
- * @param {string} value 設定する値
- * @param {object} source 使用するPrefのObject。
- */
-export function setPref(identifier: string, value: unknown, source = settings) {
-    if (identifier == "") {
-        settings = value;
-    } else {
-        const { object, key } = getPointerFromKey(source, identifier);
+    // TODO: 設定の型が厳密になれば V を T[K] に置き換えられる。
+    public get<V = any>(identifier: JsonKeyOf<T>): V {
+        const { object, key } = this.#getPointer(this.value, identifier);
+        return object[key];
+    }
+    // TODO: 補完できるようにしつつ、any な挙動を実現するために V ジェネリクスを使用している。設定の型が厳密になれば V を T[K] に置き換えられる。
+    public set<K extends JsonKeyOf<T>, V = T[K]>(identifier: K, value: V): this {
+        const { object, key } = this.#getPointer(this.value, identifier);
         object[key] = value;
+        return this;
+    }
+    public delete(identifier: JsonKeyOf<T>): this {
+        const { object, key } = this.#getPointer(this.value, identifier);
+        delete object[key];
+        return this;
     }
 }
 
-/**
- * TUICのPrefの値を削除します。
- *
- * @param {string} identifier 取得するPrefへのパス(ピリオド区切り)。
- * @param {object} source 使用するPrefのObject。
- */
-export function deletePref(identifier: string, source = settings) {
-    const { object, key } = getPointerFromKey(source, identifier);
-    delete object[key];
+// MARK: Migrates
+
+export interface MigratableNestedPreferences extends NestedPreferences<DefaultPreferencesData> {
+    // NOTE: 古い設定は型定義から削除されていることがあるため、最新の設定型定義を補完しつつ、存在しないキーを受け入れるようにする
+    // こうすることで、例えば以下のように推論される:
+    // - .get("undefinedKey"): any
+    // - .get<SomeType>("undefinedKey") -> エラー
+    // - .get<SomeType, "undefinedKey">("undefinedKey"): SomeType
+    // 存在しなくなったが強制的に使用したい、かつ値に特定の型を要求するキーを使用する際、第二ジェネリクスで明示する必要が出てくることにより、多少明示的になる
+
+    // TODO: V = any は型定義が厳密になれば T[K] に置き換えられる
+    get<V = any, K extends string = SettingKeys>(identifier: K): V;
+    set<K extends string = SettingKeys, V = any>(identifier: K, value: V): this;
+    delete<K extends string = SettingKeys>(identifier: K): this;
+}
+export class MigratableNestedPreferences extends NestedPreferences<DefaultPreferencesData> {
+    /**
+     * `oldKey` の設定が truthy であれば `newKey` に `newValue` を設定し、`oldKey` を削除します。
+     * `oldKey` の設定が falsy であれば `oldKey` の削除だけを行います。
+     *
+     * boolean 値の設定キーを変更することを想定しています。
+     * @param oldKey 変更元のキー
+     * @param newKey 変更先のキー
+     * @param newValue 指定された値が truthy だった場合の置き換え先の値
+     */
+    #migrateBoolean<K1 extends string = SettingKeys, K2 extends string = SettingKeys>(oldKey: K1, newKey: K2, newValue: string | boolean = true): void {
+        if (this.get(oldKey) === true) this.set(newKey, newValue);
+        this.delete(oldKey);
+    }
+
+    /** 設定バージョンを 0 から 1 に移行します。 */
+    async #migrateToV1(): Promise<void> {
+        if (typeof this.get("timeline") !== "object") this.set("timeline", {});
+        if (typeof this.get("rightSidebar") !== "object") this.set("rightSidebar", {});
+        if (typeof this.get("XToTwitter") !== "object") this.set("XToTwitter", {});
+        if (typeof this.get("twitterIcon") === "string") {
+            const twitterIconPref = this.get<string, "twitterIcon">("twitterIcon");
+            this.set("twitterIcon", {});
+            this.set("twitterIcon.icon", twitterIconPref);
+        }
+        if (typeof this.get("clientInfo") === "object") this.delete("clientInfo");
+
+        const boolKeys = {
+            "invisibleItems.osusume-user-timeline": "timeline.osusume-user-timeline",
+            "invisibleItems.hideOhterRTTL": "timeline.hideOhterRTTL",
+            "invisibleItems.verified-rSidebar": "rightSidebar.verified",
+            "otherBoolSetting.XtoTwitter": "XToTwitter.XToTwitter",
+            "otherBoolSetting.PostToTweet": "XToTwitter.PostToTweet",
+            "invisibleItems.twitter-pro-promotion-btn": "tweetDisplaySetting.twitter-pro-promotion-btn",
+            "invisibleItems.subscribe-tweets": "tweetDisplaySetting.subscribe-tweets",
+            "otherBoolSetting.bottomScroll": "tweetDisplaySetting.bottomScroll",
+            "otherBoolSetting.bottomSpace": "tweetDisplaySetting.bottomSpace",
+            "otherBoolSetting.RTNotQuote": "tweetDisplaySetting.RTNotQuote",
+            "otherBoolSetting.noModalbottomTweetButtons": "tweetDisplaySetting.noModalbottomTweetButtons",
+            "otherBoolSetting.noNumberBottomTweetButtons": "tweetDisplaySetting.noNumberBottomTweetButtons",
+            "invisibleItems.subscribe-profile": "profileSetting.invisible.subscribe-profile",
+            "invisibleItems.profileHighlights": "profileSetting.invisible.profileHighlights",
+            "invisibleItems.profileAffiliates": "profileSetting.invisible.profileAffiliates",
+            "invisibleItems.verifiedFollowerTab": "profileSetting.invisible.verifiedFollowerTab",
+            "otherBoolSetting.smallerSidebarContent": "sidebarSetting.buttonConfig.smallerSidebarContent",
+            "otherBoolSetting.sidebarNoneScrollbar": "sidebarSetting.buttonConfig.sidebarNoneScrollbar",
+            "otherBoolSetting.faviconSet": "twitterIcon.options.faviconSet",
+            "otherBoolSetting.roundIcon": "twitterIcon.options.roundIcon",
+        } as const;
+        for (const [oldKey, newKey] of Object.entries(boolKeys)) {
+            this.#migrateBoolean(oldKey, newKey);
+        }
+
+        this.#migrateBoolean("invisibleItems.discoverMore", "timeline-discoverMore", "discoverMore_invisible");
+        this.#migrateBoolean("otherBoolSetting.invisibleTwitterLogo", "twitterIcon", "invisible");
+        this.#migrateBoolean("sidebarSetting.buttonConfig.birdGoBackHome", "sidebarSetting.homeIcon", "birdGoBack");
+
+        if (this.get("CSS")) localStorage.setItem("TUIC_CSS", this.get<string, "CSS">("CSS"));
+        this.delete("CSS");
+
+        if (localStorage.getItem("TUIC_IconImg") !== null && localStorage.getItem("TUIC_IconImg_Favicon") === null) {
+            await new Promise((resolve, reject) => {
+                const element = document.createElement("canvas");
+                element.height = 200;
+                element.width = 200;
+                const context = element.getContext("2d");
+                context.beginPath();
+                context.arc(100, 100, 100, (0 * Math.PI) / 180, (360 * Math.PI) / 180);
+                context.clip();
+                const image = new Image();
+                image.onload = function () {
+                    context.beginPath();
+                    context.drawImage(image, 0, 0, image.naturalHeight, image.naturalWidth, 0, 0, 200, 200);
+                    localStorage.setItem("TUIC_IconImg_Favicon", element.toDataURL());
+                    resolve(null);
+                };
+                image.src = localStorage.getItem("TUIC_IconImg");
+            });
+        }
+
+        // TODO: typeof は Array.isArray にしたほうがいいのでは？
+        if (typeof this.get("visibleButtons") === "object" && this.get<string[]>("visibleButtons").includes("downvote-button")) {
+            this.set("visibleButtons", this.get<string[]>("visibleButtons").filter((elem) => elem !== "downvote-button"));
+        }
+        if (typeof this.get("sidebarButtons") == "object" && (this.get<string[]>("sidebarButtons").includes("verified-orgs-signup") || this.get<string[]>("sidebarButtons").includes("twiter-blue") || this.get<string[]>("sidebarButtons").includes("circles"))) {
+            this.set(
+                "sidebarButtons",
+                this.get<string[]>("sidebarButtons").filter((elem) => elem != "sidebarButtons-circles" && elem != "twiter-blue" && elem != "verified-orgs-signup" && elem != "circles"),
+            );
+        }
+
+        this.set("prefVersion", 1);
+    }
+
+    /** 設定バージョンを 1 から 2 に移行します。 */
+    #migrateToV2(): void {
+        if (this.get<number, "prefVersion">("prefVersion") < 1) this.#migrateToV1();
+
+        const boolKeys = {
+            "tweetDisplaySetting.twitter-pro-promotion-btn": "tweetDisplaySetting.invisible.twitter-pro-promotion-btn",
+            "tweetDisplaySetting.subscribe-tweets": "tweetDisplaySetting.invisible.subscribe-tweets",
+            "tweetDisplaySetting.bottomSpace": "tweetDisplaySetting.invisible.bottomSpace",
+            "tweetDisplaySetting.bottomScroll": "tweetDisplaySetting.option.bottomScroll",
+            "tweetDisplaySetting.RTNotQuote": "tweetDisplaySetting.buttonsInvisible.RTNotQuote",
+            "tweetDisplaySetting.noModalbottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noModalbottomTweetButtons",
+            "tweetDisplaySetting.noNumberBottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noNumberBottomTweetButtons",
+            "tweetDisplaySetting.likeToFavo": "tweetDisplaySetting.option.likeToFavo",
+            "otherBoolSetting.placeEngagementsLink": "engagementsLink.option.placeEngagementsLink",
+            "otherBoolSetting.placeEngagementsLinkShort": "engagementsLink.option.placeEngagementsLinkShort",
+            "otherBoolSetting.showLinkCardInfo": "showLinkCardInfo.showLinkCardInfo",
+        } as const;
+        for (const [oldKey, newKey] of Object.entries(boolKeys)) {
+            this.#migrateBoolean(oldKey, newKey);
+        }
+
+        this.set("prefVersion", 2);
+    }
+
+    /** 設定バージョンを 2 から 3 に移行します。 */
+    #migrateToV3(): void {
+        if (this.get<number, "prefVersion">("prefVersion") < 2) this.#migrateToV2();
+
+        const boolKeys = {
+            "tweetDisplaySetting.option.RTNotQuote": "tweetDisplaySetting.buttonsInvisible.RTNotQuote",
+            "tweetDisplaySetting.option.noModalbottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noModalbottomTweetButtons",
+            "tweetDisplaySetting.option.noNumberBottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noNumberBottomTweetButtons",
+        } as const;
+        for (const [oldKey, newKey] of Object.entries(boolKeys)) {
+            this.#migrateBoolean(oldKey, newKey);
+        }
+
+        this.set("prefVersion", 3);
+    }
+
+    /** 設定バージョンを 3 から 4 に移行します。 */
+    #migrateToV4(): void {
+        if (this.get<number, "prefVersion">("prefVersion") < 3) this.#migrateToV3();
+
+        this.#migrateBoolean("dateAndTime.options.absolutelyTime", "dateAndTime.dateAboveTweet", "absolutelyToday");
+
+        this.set("prefVersion", 4);
+    }
+
+    /** 設定バージョンを 4 から 5 に移行します。 */
+    #migrateToV5(): void {
+        if (this.get<number, "prefVersion">("prefVersion") < 4) this.#migrateToV4();
+
+        if (this.get("XToTwitter.XToTwitter")) {
+            this.set("XToTwitter.PwaManifest", true);
+        }
+        // NOTE: XToTwitter と PwaManifest の設定は独立のため、削除する必要はない。よって migrateBoolean は使用しない。
+
+        this.set("prefVersion", 5);
+    }
+
+    /**
+     * この設定を最新の設定バージョンに移行します。
+     */
+    public migrate(): DefaultPreferencesClass {
+        if (this.get<number, "prefVersion">("prefVersion") < 5) this.#migrateToV5();
+
+        return new NestedPreferences(this.value);
+    }
 }
 
-/**
- * 変更が加えられたTUICのPrefをlocalStorageへ保存します。
- */
-export function savePref() {
-    localStorage.setItem("TUIC", JSON.stringify(settings));
+// MARK: Functions
+
+/** 保存された設定を取得します。 */
+export function loadPreferences(): DefaultPreferencesClass {
+    const stored = localStorage.getItem("TUIC");
+    if (stored) {
+        return new MigratableNestedPreferences(JSON.parse(stored)).migrate();
+    } else {
+        return new NestedPreferences(mergeDefaultPref({}));
+    }
+}
+/** 指定された設定をグローバルに保存します。 */
+export function savePreferences(preferences: DefaultPreferencesClass) {
+    localStorage.setItem("TUIC", preferences.serialize());
 }
 
-/**
- * TUICのPrefのすべての値を文字列として出力します。
- *
- * @return {string} TUICのPrefをJSON.stringify()で文字列にしたもの
- */
-export function exportPref(): string {
-    return JSON.stringify(settings);
-}
+// MARK: Deprecated funcs
+// TODO: 今は応急処置で動くようにしている
 
 /**
  * `target` に `source` をマージします。 `target` オブジェクトは上書きされます。
- * @param {object} source マージ元
- * @param {object} target マージ先
+ * @param source マージ元
+ * @param target マージ先
+ * @deprecated
  */
-export function mergePref(source: object, target: object) {
+export function mergePref(source: any, target: any): any {
     for (const i in source) {
         if (!(i in target)) {
             target[i] = source[i];
@@ -96,217 +312,64 @@ export function mergePref(source: object, target: object) {
     return target;
 }
 
+let cachedDefaultData: NestedPreferences<any> | null = null;
 /**
- * boolean 値の設定キーを変更します。
- *
- * 値が truthy であれば `replaceValue` に、値が falsy であればキーを変更せず古いキーの削除だけを行います。
- * @param {string} previousKey 変更元のキー
- * @param {string} nextKey 変更先のキー
- * @param {any} replaceValue 置き換える値
+ * @deprecated
  */
-const changeBooleanKey = (previousKey: string, nextKey: string, source, replaceValue: string | boolean = true) => {
-    if (getPref(previousKey, source) === true) setPref(nextKey, replaceValue, source);
-    deletePref(previousKey, source);
-};
-
-export async function updatePref(source = settings) {
-    const prefVersion_ = getPref("prefVersion", source) ?? 0;
-    setPref("prefVersion", prefVersion);
-    switch (prefVersion_) {
-        case 0: {
-            /*
-            if (localStorage.getItem("unsent-tweet-background")) {
-                parallelToSerialPref();
-            }*/
-
-            if (typeof getPref("timeline", source) != "object") setPref("timeline", {}, source);
-
-            if (typeof getPref("rightSidebar", source) != "object") setPref("rightSidebar", {}, source);
-
-            if (typeof getPref("XToTwitter", source) != "object") setPref("XToTwitter", {}, source);
-
-            if (typeof getPref("twitterIcon", source) == "string") {
-                const twitterIconPref = getPref("twitterIcon", source);
-                setPref("twitterIcon", {}, source);
-                setPref("twitterIcon.icon", twitterIconPref, source);
-            }
-
-            if (typeof getPref("clientInfo", source) == "object") deletePref("clientInfo", source);
-
-            const boolKeys = {
-                "invisibleItems.osusume-user-timeline": "timeline.osusume-user-timeline",
-                "invisibleItems.hideOhterRTTL": "timeline.hideOhterRTTL",
-                "invisibleItems.verified-rSidebar": "rightSidebar.verified",
-                "otherBoolSetting.XtoTwitter": "XToTwitter.XToTwitter",
-                "otherBoolSetting.PostToTweet": "XToTwitter.PostToTweet",
-                "invisibleItems.twitter-pro-promotion-btn": "tweetDisplaySetting.twitter-pro-promotion-btn",
-                "invisibleItems.subscribe-tweets": "tweetDisplaySetting.subscribe-tweets",
-                "otherBoolSetting.bottomScroll": "tweetDisplaySetting.bottomScroll",
-                "otherBoolSetting.bottomSpace": "tweetDisplaySetting.bottomSpace",
-                "otherBoolSetting.RTNotQuote": "tweetDisplaySetting.RTNotQuote",
-                "otherBoolSetting.noModalbottomTweetButtons": "tweetDisplaySetting.noModalbottomTweetButtons",
-                "otherBoolSetting.noNumberBottomTweetButtons": "tweetDisplaySetting.noNumberBottomTweetButtons",
-                "invisibleItems.subscribe-profile": "profileSetting.invisible.subscribe-profile",
-                "invisibleItems.profileHighlights": "profileSetting.invisible.profileHighlights",
-                "invisibleItems.profileAffiliates": "profileSetting.invisible.profileAffiliates",
-                "invisibleItems.verifiedFollowerTab": "profileSetting.invisible.verifiedFollowerTab",
-                "otherBoolSetting.smallerSidebarContent": "sidebarSetting.buttonConfig.smallerSidebarContent",
-                "otherBoolSetting.sidebarNoneScrollbar": "sidebarSetting.buttonConfig.sidebarNoneScrollbar",
-                "otherBoolSetting.faviconSet": "twitterIcon.options.faviconSet",
-                "otherBoolSetting.roundIcon": "twitterIcon.options.roundIcon",
-            };
-            for (const oldKey in boolKeys) {
-                changeBooleanKey(oldKey, boolKeys[oldKey], source);
-            }
-
-            changeBooleanKey("invisibleItems.discoverMore", "timeline-discoverMore", source, "discoverMore_invisible");
-            changeBooleanKey("otherBoolSetting.invisibleTwitterLogo", "twitterIcon", source, "invisible");
-            changeBooleanKey("sidebarSetting.buttonConfig.birdGoBackHome", "sidebarSetting.homeIcon", source, "birdGoBack");
-
-            if (getPref("CSS", source)) localStorage.setItem("TUIC_CSS", getPref("CSS"));
-            deletePref("CSS", source);
-
-            if (localStorage.getItem("TUIC_IconImg") != null && localStorage.getItem("TUIC_IconImg_Favicon") == null) {
-                await new Promise((resolve, reject) => {
-                    const element = document.createElement("canvas");
-                    element.height = 200;
-                    element.width = 200;
-                    const context = element.getContext("2d");
-                    context.beginPath();
-                    context.arc(100, 100, 100, (0 * Math.PI) / 180, (360 * Math.PI) / 180);
-                    context.clip();
-                    const image = new Image();
-                    image.onload = function () {
-                        context.beginPath();
-                        context.drawImage(image, 0, 0, image.naturalHeight, image.naturalWidth, 0, 0, 200, 200);
-                        localStorage.setItem("TUIC_IconImg_Favicon", element.toDataURL());
-                        resolve(null);
-                    };
-                    image.src = localStorage.getItem("TUIC_IconImg");
-                });
-            }
-
-            if (typeof getPref("visibleButtons", source) == "object" && getPref("visibleButtons", source).includes("downvote-button")) {
-                setPref(
-                    "visibleButtons",
-                    getPref("visibleButtons", source).filter((elem: string) => elem != "downvote-button"),
-                    source,
-                );
-            }
-            if (typeof getPref("sidebarButtons", source) == "object" && (getPref("sidebarButtons", source).includes("verified-orgs-signup") || getPref("sidebarButtons", source).includes("twiter-blue") || getPref("sidebarButtons", source).includes("circles"))) {
-                setPref(
-                    "sidebarButtons",
-                    getPref("sidebarButtons", source).filter((elem: string) => elem != "sidebarButtons-circles" && elem != "twiter-blue" && elem != "verified-orgs-signup" && elem != "circles"),
-                    source,
-                );
-            }
-            // fall through
-        }
-        case 1: {
-            const boolKeys = {
-                "tweetDisplaySetting.twitter-pro-promotion-btn": "tweetDisplaySetting.invisible.twitter-pro-promotion-btn",
-                "tweetDisplaySetting.subscribe-tweets": "tweetDisplaySetting.invisible.subscribe-tweets",
-                "tweetDisplaySetting.bottomSpace": "tweetDisplaySetting.invisible.bottomSpace",
-                "tweetDisplaySetting.bottomScroll": "tweetDisplaySetting.option.bottomScroll",
-                "tweetDisplaySetting.RTNotQuote": "tweetDisplaySetting.buttonsInvisible.RTNotQuote",
-                "tweetDisplaySetting.noModalbottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noModalbottomTweetButtons",
-                "tweetDisplaySetting.noNumberBottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noNumberBottomTweetButtons",
-                "tweetDisplaySetting.likeToFavo": "tweetDisplaySetting.option.likeToFavo",
-                "otherBoolSetting.placeEngagementsLink": "engagementsLink.option.placeEngagementsLink",
-                "otherBoolSetting.placeEngagementsLinkShort": "engagementsLink.option.placeEngagementsLinkShort",
-                "otherBoolSetting.showLinkCardInfo": "showLinkCardInfo.showLinkCardInfo",
-            };
-            for (const oldKey in boolKeys) {
-                changeBooleanKey(oldKey, boolKeys[oldKey], source);
-            }
-            // falls through
-        }
-        case 2: {
-            const boolKeys = {
-                "tweetDisplaySetting.option.RTNotQuote": "tweetDisplaySetting.buttonsInvisible.RTNotQuote",
-                "tweetDisplaySetting.option.noModalbottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noModalbottomTweetButtons",
-                "tweetDisplaySetting.option.noNumberBottomTweetButtons": "tweetDisplaySetting.buttonsInvisible.noNumberBottomTweetButtons",
-            };
-            for (const oldKey in boolKeys) {
-                changeBooleanKey(oldKey, boolKeys[oldKey], source);
-            }
-            // falls through
-        }
-        case 3: {
-            if (getPref("dateAndTime.options.absolutelyTime", source)) {
-                setPref("dateAndTime.dateAboveTweet", "absolutelyToday", source);
-            }
-            deletePref("dateAndTime.options.absolutelyTime", source);
-            // falls through
-        }
-        case 4: {
-            if (getPref("XToTwitter.XToTwitter", source)) {
-                setPref("XToTwitter.PwaManifest", true, source);
-            }
-        }
-    }
-}
-
-let defaultData = null;
-
-export function mergeDefaultPref(source) {
-    if (defaultData == null) {
-        defaultData = {};
-        for (const elem in DEFAULT_SETTINGS) {
-            if (elem == "buttonColor") {
-                defaultData.buttonColor = {};
-                defaultData.buttonColorLight = {};
-                defaultData.buttonColorDark = {};
+export function mergeDefaultPref(source: any): any {
+    if (cachedDefaultData == null) {
+        let preferences = new NestedPreferences<any>({});
+        for (const key of Object.keys(DEFAULT_SETTINGS) as SettingKeys[]) {
+            if (key == "buttonColor") {
+                preferences.set("buttonColor", {});
+                preferences.set("buttonColorLight", {});
+                preferences.set("buttonColorDark", {});
             } else {
-                const defaultReturn = getDefaultPref(elem);
-                switch (defaultReturn.type) {
-                    case "boolean": {
-                        for (const data in defaultReturn.data) {
-                            setPref(`${elem}.${data}`, defaultReturn.data[data], defaultData);
-                        }
-                        break;
+                const defaultData = getDefaultPref(key);
+                if (defaultData.type === "boolean") {
+                    const defaultDataKeys = Object.keys(defaultData.data) as (keyof typeof defaultData.data)[];
+                    for (const data of defaultDataKeys) {
+                        preferences.set(`${key}.${data}`, defaultData.data[data]);
                     }
-                    case "select": {
-                        setPref(elem, defaultReturn.data, defaultData);
-                        break;
-                    }
-                    case "order": {
-                        setPref(elem, structuredClone(defaultReturn.data), defaultData);
-                        break;
-                    }
+                } else if (defaultData.type === "select") {
+                    preferences.set(key, defaultData.data);
+                } else if (defaultData.type === "order") {
+                    preferences.set(key, structuredClone(defaultData.data));
                 }
             }
         }
+        cachedDefaultData = preferences;
     }
-    return mergePref(structuredClone(defaultData), structuredClone(source));
+    return mergePref(structuredClone(cachedDefaultData), structuredClone(source));
 }
 
-export function getDefaultPref(id: string) {
+/**
+ * @deprecated
+ */
+export function getDefaultPref(id: SettingKeys) {
     const prefData = DEFAULT_SETTINGS[id];
-    switch (prefData.type) {
-        case "boolean": {
-            const returnObject = {};
-            for (const elem of prefData.values) {
-                returnObject[elem.id] = elem.default ?? false;
-            }
-            return { data: returnObject, type: prefData.type };
+    if (prefData.type === "boolean") {
+        const returnObject: Record<typeof prefData.values[number]["id"], boolean> = {} as any;
+        for (const elem of prefData.values) {
+            returnObject[elem.id] = elem.default ?? false;
         }
-        case "order": {
-            return { data: structuredClone(prefData.default), type: prefData.type };
-        }
-        case "select": {
-            return { data: prefData.default, type: prefData.type };
-        }
+        return { data: returnObject, type: prefData.type };
+    } else if (prefData.type === "order") {
+        return { data: structuredClone(prefData.default), type: prefData.type };
+    } else if (prefData.type === "select") {
+        return { data: prefData.default, type: prefData.type };
+    } else {
+        // NOTE: ここには来ないはず
+        throw new Error(`Invalid setting type: ${prefData.type}`);
     }
 }
-
-const prefVersion = 5;
 
 /**
  * 指定した設定カテゴリーIDに基づいて値の一覧(CheckboxならCheckboxの全てのID、RadioBox/ListBoxなら値になりうるすべての値)を出力します
  *
  * @param {string} id 設定カテゴリーID
  * @return {string[]} 取得した値一覧
+ * @deprecated
  */
 export function getSettingIDs<T extends SettingKeys>(id: T): (typeof DEFAULT_SETTINGS)[T]["values"][number]["id"][] {
     return DEFAULT_SETTINGS[id].values.map((elem) => elem.id);
@@ -317,6 +380,7 @@ export function getSettingIDs<T extends SettingKeys>(id: T): (typeof DEFAULT_SET
  *
  * @param {string} id 設定カテゴリーID
  * @return {{id:string,i18n:string}[]} 取得したデータ
+ * @deprecated
  */
 export function getSettingData<T extends SettingKeys>(id: T): (typeof DEFAULT_SETTINGS)[T]["values"] {
     return DEFAULT_SETTINGS[id].values;
@@ -328,9 +392,8 @@ export function getSettingData<T extends SettingKeys>(id: T): (typeof DEFAULT_SE
  * @param {string} id 設定カテゴリーID
  * @param {string} id 設定自体のID(設定カテゴリーIDを除く)
  * @return {string} i18nのID
+ * @deprecated
  */
 export function getSettingI18n<T extends SettingKeys>(id: T, itemValue: (typeof DEFAULT_SETTINGS)[T]["values"][number]["id"]): string {
     return DEFAULT_SETTINGS[id].values.filter((elem) => elem.id == itemValue)[0]?.i18n ?? undefined;
 }
-
-settings = JSON.parse(localStorage.getItem("TUIC") ?? JSON.stringify(mergeDefaultPref({})));

--- a/src/shared/settings/modules/settingImportExport.vue
+++ b/src/shared/settings/modules/settingImportExport.vue
@@ -78,7 +78,7 @@
 
 <script setup lang="ts">
 import { translate } from "@content/i18n";
-import { getPref, setPref, savePref, updatePref, mergePref, mergeDefaultPref, exportPref } from "@content/settings";
+import { getPref, setPref, savePref, mergePref, mergeDefaultPref, exportPref } from "@content/settings";
 import { waitForElement } from "@content/utils/element";
 import { injectSettingsStyle, cleanModifiedElements } from "@content/applyCSS";
 import { Dialog } from "@shared/tlui/components/Dialog";

--- a/src/shared/settings/modules/settingImportExport.vue
+++ b/src/shared/settings/modules/settingImportExport.vue
@@ -120,7 +120,7 @@ const importFunc = async (type: number) => {
             localStorage.setItem("TUIC_CSS", importedPref.CustomCSS);
             delete importedPref.CustomCSS;
         }
-        await updatePref(importedPref);
+        await migratePref(importedPref);
         if (type == 1) {
             setPref("", mergePref(getPref(""), importedPref));
         } else if (type == 2) {


### PR DESCRIPTION
設定画面を大改訂し、以下の変更を行いました:
- getPref, setPref, deletePref, exportPref, ... を Preferences クラスと NestedPreferences クラスが担当する
- mergePref, updatePref を MigratableNestedPreferences クラスが担当する
- savePref を loadPreferences(), savePreferences() が担当する

まだ getPref, setPref, deletePref あたりの依存関係が残っている（＝動作しない）のでドラフト

とここまで書いて、#272 と思いっきりコンフリクトすることに気づいた（どうしよう）（本当にどうしよう）
追記）思ったよりとんでもないって感じでもないかも（#272 の変更は実装じゃなくて型定義関連が多い？）