### PR TITLE
Support X History and legacy Bookmarks sidebar routes

### DIFF
--- a/src/content/functions/sidebar/buttons/bookmarks.tsx
+++ b/src/content/functions/sidebar/buttons/bookmarks.tsx
@@ -2,13 +2,14 @@ import type { SidebarButtonDefinition } from "../types";
 import { createSidebarButton } from "../components";
 import { SIDEBAR_BUTTON_ICON } from "@shared/icons";
 import { buttonClickInMoreMenu } from "../utils";
+import { SidebarHistory } from "../constants";
 
 export const bookmarks: SidebarButtonDefinition = () => createSidebarButton({
-    id: "bookmarks",
+    id: SidebarHistory.legacyId,
     svg: () => <path d={SIDEBAR_BUTTON_ICON.bookmarks.unselected}></path>,
-    url: "/i/bookmarks",
+    url: SidebarHistory.route,
     onclick: (e: Event) => {
         e?.preventDefault?.();
-        buttonClickInMoreMenu(`[href="/i/bookmarks"]`);
+        buttonClickInMoreMenu(SidebarHistory.link);
     },
 });

--- a/src/content/functions/sidebar/buttons/bookmarks.tsx
+++ b/src/content/functions/sidebar/buttons/bookmarks.tsx
@@ -2,14 +2,14 @@ import type { SidebarButtonDefinition } from "../types";
 import { createSidebarButton } from "../components";
 import { SIDEBAR_BUTTON_ICON } from "@shared/icons";
 import { buttonClickInMoreMenu } from "../utils";
-import { SidebarHistory } from "../constants";
+import { SidebarBookmarks } from "../constants";
 
 export const bookmarks: SidebarButtonDefinition = () => createSidebarButton({
-    id: SidebarHistory.legacyId,
+    id: SidebarBookmarks.id,
     svg: () => <path d={SIDEBAR_BUTTON_ICON.bookmarks.unselected}></path>,
-    url: SidebarHistory.route,
+    url: () => document.querySelector<HTMLAnchorElement>(SidebarBookmarks.native)?.href ?? SidebarBookmarks.currentRoute,
     onclick: (e: Event) => {
         e?.preventDefault?.();
-        buttonClickInMoreMenu(SidebarHistory.link);
+        buttonClickInMoreMenu(SidebarBookmarks.link);
     },
 });

--- a/src/content/functions/sidebar/constants.ts
+++ b/src/content/functions/sidebar/constants.ts
@@ -1,0 +1,9 @@
+/** X replaced the Bookmarks destination with History; keep the legacy ID for stored preferences. */
+export class SidebarHistory {
+    static readonly legacyId = "bookmarks";
+    static readonly route = "/i/history";
+    static readonly link = `[href="${SidebarHistory.route}"]`;
+    static readonly custom = `#TUICSidebar_${SidebarHistory.legacyId}`;
+    static readonly button = `${SidebarHistory.link},${SidebarHistory.custom}`;
+    static readonly native = `${SidebarHistory.link}:not(${SidebarHistory.custom})`;
+}

--- a/src/content/functions/sidebar/constants.ts
+++ b/src/content/functions/sidebar/constants.ts
@@ -1,9 +1,13 @@
-/** X replaced the Bookmarks destination with History; keep the legacy ID for stored preferences. */
-export class SidebarHistory {
-    static readonly legacyId = "bookmarks";
-    static readonly route = "/i/history";
-    static readonly link = `[href="${SidebarHistory.route}"]`;
-    static readonly custom = `#TUICSidebar_${SidebarHistory.legacyId}`;
-    static readonly button = `${SidebarHistory.link},${SidebarHistory.custom}`;
-    static readonly native = `${SidebarHistory.link}:not(${SidebarHistory.custom})`;
+/** Supports X's current History route and legacy Bookmarks route with one persisted key. */
+export class SidebarBookmarks {
+    static readonly id = "bookmarks";
+    static readonly currentRoute = "/i/history";
+    static readonly legacyRoute = "/i/bookmarks";
+    static readonly routes = [SidebarBookmarks.currentRoute, SidebarBookmarks.legacyRoute] as const;
+    static readonly currentLink = `[href="${SidebarBookmarks.currentRoute}"]`;
+    static readonly legacyLink = `[href="${SidebarBookmarks.legacyRoute}"]`;
+    static readonly link = `:is(${SidebarBookmarks.currentLink},${SidebarBookmarks.legacyLink})`;
+    static readonly custom = `#TUICSidebar_${SidebarBookmarks.id}`;
+    static readonly button = `${SidebarBookmarks.link},${SidebarBookmarks.custom}`;
+    static readonly native = `${SidebarBookmarks.link}:not(${SidebarBookmarks.custom})`;
 }

--- a/src/content/functions/sidebar/extras/dropdown.ts
+++ b/src/content/functions/sidebar/extras/dropdown.ts
@@ -1,13 +1,13 @@
 import { hideElement, waitForElement } from "@content/utils/element";
 import { fontSizeClass } from "@content/utils/fontSize";
 import { getPref, getSettingIDs } from "@content/settings";
-import { SidebarHistory } from "../constants";
+import { SidebarBookmarks } from "../constants";
 
 const _data = {
     all: getSettingIDs("sidebarSetting.moreMenuItems"),
     selectors: {
         lists: `[href$="/lists"]`,
-        [SidebarHistory.legacyId]: SidebarHistory.link,
+        [SidebarBookmarks.id]: SidebarBookmarks.link,
         monetization: `:is([href="/settings/monetization"],[href="/i/monetization"])`,
         separator: `[role="separator"]`,
         creatorStudio: `:is([aria-controls$="_0_content"], [href="/i/jf/creators/studio"])`,

--- a/src/content/functions/sidebar/extras/dropdown.ts
+++ b/src/content/functions/sidebar/extras/dropdown.ts
@@ -1,12 +1,13 @@
 import { hideElement, waitForElement } from "@content/utils/element";
 import { fontSizeClass } from "@content/utils/fontSize";
 import { getPref, getSettingIDs } from "@content/settings";
+import { SidebarHistory } from "../constants";
 
 const _data = {
     all: getSettingIDs("sidebarSetting.moreMenuItems"),
     selectors: {
         lists: `[href$="/lists"]`,
-        bookmarks: `[href="/i/bookmarks"]`,
+        [SidebarHistory.legacyId]: SidebarHistory.link,
         monetization: `:is([href="/settings/monetization"],[href="/i/monetization"])`,
         separator: `[role="separator"]`,
         creatorStudio: `:is([aria-controls$="_0_content"], [href="/i/jf/creators/studio"])`,

--- a/src/content/functions/sidebar/index.ts
+++ b/src/content/functions/sidebar/index.ts
@@ -3,7 +3,7 @@ import { hideElement } from "@content/utils/element";
 import { getPref } from "@content/settings";
 import { processDropdown } from "./extras/dropdown";
 import { sidebarButtonsData } from "./buttons";
-import { SidebarHistory } from "./constants";
+import { SidebarBookmarks } from "./constants";
 
 let sidebarButtonsCount = -1;
 
@@ -13,7 +13,7 @@ export const SidebarButtonSelectors = {
     communities: '[href$="/communities"],#TUICSidebar_communities',
     notifications: '[href*="/notifications"]',
     messages: '[href^="/messages"], #TUICSidebar_chat, [href="/i/chat"]',
-    [SidebarHistory.legacyId]: SidebarHistory.button,
+    [SidebarBookmarks.id]: SidebarBookmarks.button,
     profile: '[data-testid="AppTabBar_Profile_Link"]',
     moremenu: '[data-testid="AppTabBar_More_Menu"]',
     topics: "#TUICSidebar_topics",
@@ -43,12 +43,12 @@ export function sidebarButtons() {
 
     const bannerRoot = document.querySelector<HTMLElement>(`[role=banner] > ${"div >".repeat(5)} nav`);
     if (bannerRoot) {
-        const vanillaHistory = bannerRoot.querySelector(SidebarHistory.native);
-        const tuicHistory = bannerRoot.querySelector(SidebarHistory.custom);
-        if (vanillaHistory && tuicHistory) {
-            tuicHistory.remove();
+        const nativeBookmarks = bannerRoot.querySelector(SidebarBookmarks.native);
+        const customBookmarks = bannerRoot.querySelector(SidebarBookmarks.custom);
+        if (nativeBookmarks && customBookmarks) {
+            customBookmarks.remove();
             placeSidebarButtons(bannerRoot);
-        } else if (getPref("sidebarButtons").includes(SidebarHistory.legacyId) && !(vanillaHistory || tuicHistory)) {
+        } else if (getPref("sidebarButtons").includes(SidebarBookmarks.id) && !(nativeBookmarks || customBookmarks)) {
             placeSidebarButtons(bannerRoot);
         } else if (bannerRoot.querySelector(`a:not([data-tuic-hide])`)) {
             placeSidebarButtons(bannerRoot);

--- a/src/content/functions/sidebar/index.ts
+++ b/src/content/functions/sidebar/index.ts
@@ -3,6 +3,7 @@ import { hideElement } from "@content/utils/element";
 import { getPref } from "@content/settings";
 import { processDropdown } from "./extras/dropdown";
 import { sidebarButtonsData } from "./buttons";
+import { SidebarHistory } from "./constants";
 
 let sidebarButtonsCount = -1;
 
@@ -12,7 +13,7 @@ export const SidebarButtonSelectors = {
     communities: '[href$="/communities"],#TUICSidebar_communities',
     notifications: '[href*="/notifications"]',
     messages: '[href^="/messages"], #TUICSidebar_chat, [href="/i/chat"]',
-    bookmarks: '[href="/i/bookmarks"],#TUICSidebar_bookmarks',
+    [SidebarHistory.legacyId]: SidebarHistory.button,
     profile: '[data-testid="AppTabBar_Profile_Link"]',
     moremenu: '[data-testid="AppTabBar_More_Menu"]',
     topics: "#TUICSidebar_topics",
@@ -42,12 +43,12 @@ export function sidebarButtons() {
 
     const bannerRoot = document.querySelector<HTMLElement>(`[role=banner] > ${"div >".repeat(5)} nav`);
     if (bannerRoot) {
-        const vanillaBookmark = document.querySelector(`[href="/i/bookmarks"]:not(#TUICSidebar_bookmarks)`);
-        const tuicBookmark = document.querySelector(`#TUICSidebar_bookmarks`);
-        if (vanillaBookmark && tuicBookmark) {
-            tuicBookmark.remove();
+        const vanillaHistory = bannerRoot.querySelector(SidebarHistory.native);
+        const tuicHistory = bannerRoot.querySelector(SidebarHistory.custom);
+        if (vanillaHistory && tuicHistory) {
+            tuicHistory.remove();
             placeSidebarButtons(bannerRoot);
-        } else if (getPref("sidebarButtons").includes("bookmarks") && !(vanillaBookmark || tuicBookmark)) {
+        } else if (getPref("sidebarButtons").includes(SidebarHistory.legacyId) && !(vanillaHistory || tuicHistory)) {
             placeSidebarButtons(bannerRoot);
         } else if (bannerRoot.querySelector(`a:not([data-tuic-hide])`)) {
             placeSidebarButtons(bannerRoot);

--- a/src/content/functions/updateStyles.ts
+++ b/src/content/functions/updateStyles.ts
@@ -5,6 +5,7 @@ import { ProcessedClass } from "@shared/sharedData";
 import { SidebarButtonSelectors } from "./sidebar";
 import { ButtonUnderTweetSelectors } from "./tweetSettings/_data";
 import { hasClosest, processElement } from "@content/utils/element";
+import { SidebarHistory } from "./sidebar/constants";
 
 let fontSize1 = "";
 let fontSize2: boolean | null = null;
@@ -32,7 +33,7 @@ const tuicButtonUrl = {
     drafts: "/compose/tweet/unsent/",
     display: ["/i/display", "/settings/display"],
     muteAndBlock: "/settings/mute_and_block",
-    bookmarks: "/i/bookmarks",
+    [SidebarHistory.legacyId]: SidebarHistory.route,
     settings: ["/settings", "/settings/"],
     jobs: "/jobs",
     spaces: "/i/spaces/start",

--- a/src/content/functions/updateStyles.ts
+++ b/src/content/functions/updateStyles.ts
@@ -5,7 +5,7 @@ import { ProcessedClass } from "@shared/sharedData";
 import { SidebarButtonSelectors } from "./sidebar";
 import { ButtonUnderTweetSelectors } from "./tweetSettings/_data";
 import { hasClosest, processElement } from "@content/utils/element";
-import { SidebarHistory } from "./sidebar/constants";
+import { SidebarBookmarks } from "./sidebar/constants";
 
 let fontSize1 = "";
 let fontSize2: boolean | null = null;
@@ -33,7 +33,7 @@ const tuicButtonUrl = {
     drafts: "/compose/tweet/unsent/",
     display: ["/i/display", "/settings/display"],
     muteAndBlock: "/settings/mute_and_block",
-    [SidebarHistory.legacyId]: SidebarHistory.route,
+    [SidebarBookmarks.id]: SidebarBookmarks.routes,
     settings: ["/settings", "/settings/"],
     jobs: "/jobs",
     spaces: "/i/spaces/start",


### PR DESCRIPTION
## Summary

- Support X's current `/i/history` route and legacy `/i/bookmarks` route throughout sidebar processing.
- Reuse the native route-specific entry and remove only the redundant custom button.
- Preserve the `bookmarks` preference and translation keys without a settings migration.
- Resolve custom fallback links against an available native route.

## Root cause

X changed the Bookmarks destination to History. A History-only replacement would no longer recognize older X sidebars that still expose `/i/bookmarks`.

## Impact

Configured sidebar ordering, More-menu handling, and selected-state styling work with either route. Existing preferences and localized native labels remain compatible.

## Validation

- `pnpm run lint:tsc`
- Targeted ESLint for the changed files
- `pnpm run build:chromium`
- Built-bundle inspection confirming both `/i/history` and `/i/bookmarks`
- Live X DOM verification of the current native History sidebar entry